### PR TITLE
스프링 컨테이너와 스프링빈

### DIFF
--- a/src/main/resources/appConfig.xml
+++ b/src/main/resources/appConfig.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd">
+    <bean id="memberService" class="study.spring.core.basic.hello.member.MemberServiceImpl" >
+        <constructor-arg name="memberRepository" ref="memberRepository" />
+    </bean>
+
+    <bean id="memberRepository" class="study.spring.core.basic.hello.member.MemoryMemberRepository"/>
+
+    <bean id="orderService" class="study.spring.core.basic.hello.order.OrderServiceImpl">
+        <constructor-arg name="memberRepository" ref="memberRepository" />
+        <constructor-arg name="discountPolicy" ref="discountPolicy" />
+    </bean>
+
+    <bean id="discountPolicy" class="study.spring.core.basic.hello.discount.RateDiscountPolicy"/>
+</beans>

--- a/src/test/java/study/spring/core/basic/hello/beandefinition/BeanDefinitionTest.java
+++ b/src/test/java/study/spring/core/basic/hello/beandefinition/BeanDefinitionTest.java
@@ -1,0 +1,24 @@
+package study.spring.core.basic.hello.beandefinition;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import study.spring.core.basic.hello.AppConfig;
+
+public class BeanDefinitionTest {
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @Test
+    @DisplayName("빈 설정 메타정보 확인")
+    void findApplicationBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String beanDefinitionName : beanDefinitionNames) {
+            BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinitionName);
+
+            if (beanDefinition.getRole() == BeanDefinition.ROLE_APPLICATION) {
+                System.out.println("beanDefinitionName = " + beanDefinitionName + " beanDefinition = " + beanDefinition);
+            }
+        }
+    }
+}

--- a/src/test/java/study/spring/core/basic/hello/beanfind/ApplicationContextBasicFindTest.java
+++ b/src/test/java/study/spring/core/basic/hello/beanfind/ApplicationContextBasicFindTest.java
@@ -1,0 +1,45 @@
+package study.spring.core.basic.hello.beanfind;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import study.spring.core.basic.hello.AppConfig;
+import study.spring.core.basic.hello.member.MemberService;
+import study.spring.core.basic.hello.member.MemberServiceImpl;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class ApplicationContextBasicFindTest {
+
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @Test
+    @DisplayName("빈 이름으로 조회")
+    void findBeanByName() {
+        MemberService memberService = ac.getBean("memberService", MemberService.class);
+        assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+
+    @Test
+    @DisplayName("빈 타입으로 조회")
+    void findBeanByType() {
+        MemberService memberService = ac.getBean(MemberService.class);
+        assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+
+    @Test
+    @DisplayName("구체 타입으로 조회")  // 구체타입으로 조회하면 유연성이 떨어진다. 역할과 구현은 구분되야하고 역할에 의존되어야하기 때문에 이코드가 좋은 코드는 아니다.
+    void findBeanByType2() {
+        MemberServiceImpl memberService = ac.getBean("memberService", MemberServiceImpl.class);
+        assertThat(memberService).isInstanceOf(MemberServiceImpl.class);
+    }
+
+    @Test
+    @DisplayName("빈 이름으로 조회 실패")
+    void findBeanByNameX() {
+        // NoSuchBeanDefinitionException 무조건 예외가 터져야 테스트가 성공한다.
+        assertThrows(NoSuchBeanDefinitionException.class, () -> ac.getBean("xxxx", MemberService.class));
+    }
+}

--- a/src/test/java/study/spring/core/basic/hello/beanfind/ApplicationContextExtendsTest.java
+++ b/src/test/java/study/spring/core/basic/hello/beanfind/ApplicationContextExtendsTest.java
@@ -1,0 +1,73 @@
+package study.spring.core.basic.hello.beanfind;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import study.spring.core.basic.hello.discount.DiscountPolicy;
+import study.spring.core.basic.hello.discount.FixDiscountPolicy;
+import study.spring.core.basic.hello.discount.RateDiscountPolicy;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ApplicationContextExtendsTest {
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(TestConfig.class);
+
+    @Test
+    @DisplayName("부모타입으로 조회시 자식이 둘 이상 있으면, 중복오류가 발생한다")
+    void findBeanByParentTypeDuplicate() {
+        DiscountPolicy bean = ac.getBean(DiscountPolicy.class);
+        assertThrows(NoUniqueBeanDefinitionException.class, () -> ac.getBean(DiscountPolicy.class));
+    }
+
+    @Test
+    @DisplayName("부모타입으로 조회시 자식이 둘 이상 있으면, 빈 이름을 등록하면된다.")
+    void findBeanByParentTypeBeanName() {
+        DiscountPolicy rateDiscountPolicy = ac.getBean("rateDiscountPolicy", DiscountPolicy.class);
+        assertThat(rateDiscountPolicy).isInstanceOf(RateDiscountPolicy.class);
+    }
+
+    @Test
+    @DisplayName("부모타입으로 모두 조회하기")
+    void findAllBeanByParentType() {
+        Map<String, DiscountPolicy> beansOfType = ac.getBeansOfType(DiscountPolicy.class);
+        assertThat(beansOfType.size()).isEqualTo(2);
+        for (String key : beansOfType.keySet()) {
+            System.out.println("key = " + key + " value = " + beansOfType.get(key));
+        }
+    }
+
+    @Test
+    @DisplayName("부모타입으로 모두 조회하기 - Object")
+    void findAllBeanByObjectType() {
+        Map<String, Object> beansOfType = ac.getBeansOfType(Object.class);
+        for (String key : beansOfType.keySet()) {
+            System.out.println("key = " + key + " value = " + beansOfType.get(key));
+        }
+    }
+
+    @Test
+    @DisplayName("특정 하위 타입으로 조회")
+    void findBeanBySubType() {
+        RateDiscountPolicy rateDiscountPolicy = ac.getBean(RateDiscountPolicy.class);
+        assertThat(rateDiscountPolicy).isInstanceOf(RateDiscountPolicy.class);
+    }
+
+    @Configuration
+    static class TestConfig {
+        @Bean
+        public DiscountPolicy rateDiscountPolicy() {
+            return new RateDiscountPolicy();
+        }
+
+        @Bean
+        public DiscountPolicy fixDiscountPolicy() {
+            return new FixDiscountPolicy();
+        }
+    }
+}

--- a/src/test/java/study/spring/core/basic/hello/beanfind/ApplicationContextInfoTest.java
+++ b/src/test/java/study/spring/core/basic/hello/beanfind/ApplicationContextInfoTest.java
@@ -1,0 +1,37 @@
+package study.spring.core.basic.hello.beanfind;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import study.spring.core.basic.hello.AppConfig;
+
+public class ApplicationContextInfoTest {
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(AppConfig.class);
+
+    @Test
+    @DisplayName("모든 빈 출력하기")
+    void findAllBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String beanDefinitionName : beanDefinitionNames) {
+            Object bean = ac.getBean(beanDefinitionName);
+            System.out.println("name = " + beanDefinitionName + "object = " + bean);
+        }
+    }
+
+    @Test
+    @DisplayName("애플리케이션 빈 출력하기")
+    void findApplicationBean() {
+        String[] beanDefinitionNames = ac.getBeanDefinitionNames();
+        for (String beanDefinitionName : beanDefinitionNames) {
+            BeanDefinition beanDefinition = ac.getBeanDefinition(beanDefinitionName);
+
+            // Role ROLE_APPLICATION : 직접 등록한 애플리케이션 빈
+            // Role ROLE_INFRASTRUCTURE : 스프링 내부에서 사용하는 빈
+            if (beanDefinition.getRole() == BeanDefinition.ROLE_APPLICATION) {
+                Object bean = ac.getBean(beanDefinitionName);
+                System.out.println("name = " + beanDefinitionName + " object = " + bean);
+            }
+        }
+    }
+}

--- a/src/test/java/study/spring/core/basic/hello/beanfind/ApplicationContextSameBeanFindTest.java
+++ b/src/test/java/study/spring/core/basic/hello/beanfind/ApplicationContextSameBeanFindTest.java
@@ -1,0 +1,64 @@
+package study.spring.core.basic.hello.beanfind;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.NoUniqueBeanDefinitionException;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import study.spring.core.basic.hello.AppConfig;
+import study.spring.core.basic.hello.member.MemberRepository;
+import study.spring.core.basic.hello.member.MemoryMemberRepository;
+
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+public class ApplicationContextSameBeanFindTest {
+    AnnotationConfigApplicationContext ac = new AnnotationConfigApplicationContext(SameBeanConfig.class);
+
+    @Test
+    @DisplayName("타입으로 조회시 같은 타입이 둘이상 있으면 중복오류가 발생한다.")
+    void findBeanByTypeDuplicate() {
+        MemberRepository bean = ac.getBean(MemberRepository.class);
+        assertThrows(NoUniqueBeanDefinitionException.class, () -> ac.getBean(MemberRepository.class));
+    }
+
+    @Test
+    @DisplayName("타입으로 조회시 같은 타입이 둘이상 있으면, 빈 이름을 지정하면 된다")
+    void findBeanByName(){
+        MemberRepository memberRepository = ac.getBean("memberRepository1", MemberRepository.class);
+        assertThat(memberRepository).isInstanceOf(MemberRepository.class);
+    }
+
+    @Test
+    @DisplayName("특정 타입을 모두 조회하기")
+    void findAllBeanByType() {
+        Map<String, MemberRepository> beansOfType = ac.getBeansOfType(MemberRepository.class);
+        for (String key : beansOfType.keySet()) {
+            System.out.println("key = " + key + " value = " + beansOfType.get(key));
+        }
+
+        System.out.println("beansOfType = " + beansOfType);
+        assertThat(beansOfType.size()).isEqualTo(2);
+    }
+
+
+    @Configuration
+    static class SameBeanConfig {
+
+        @Bean
+        public MemberRepository memberRepository1() {
+            return new MemoryMemberRepository();
+        }
+
+        @Bean
+        public MemberRepository memberRepository2() {
+            return new MemoryMemberRepository();
+        }
+
+    }
+
+}

--- a/src/test/java/study/spring/core/basic/hello/xml/XmlAppContext.java
+++ b/src/test/java/study/spring/core/basic/hello/xml/XmlAppContext.java
@@ -1,0 +1,17 @@
+package study.spring.core.basic.hello.xml;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.support.GenericXmlApplicationContext;
+import study.spring.core.basic.hello.member.MemberService;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class XmlAppContext {
+    @Test
+    void xmlAppContext() {
+        ApplicationContext ac = new GenericXmlApplicationContext("appConfig.xml");
+        MemberService memberService = ac.getBean("memberService", MemberService.class);
+        assertThat(memberService).isInstanceOf(MemberService.class);
+    }
+}


### PR DESCRIPTION
- 스프링 컨테이너 생성
- 컨테이너에 등록된 모든 빈조회
- 스프링빈 조회 - 기본
- 스프링빈 조회 - 동일한 타입이 둘이상
- 스프링빈 조회 - 상속 관계
- BeanFactory와 ApplicationContext
    - BeanFactory: 스프링 컨테이너의 최상위 `인터페이스`
        - 스프링 빈을 관리하고 조회하는 역할을 담당
        - getBean 제공
    - ApplicationContext
       - BeanFactory 기능을 모두 상속 받아서 제공한다
       - 빈을 관리하고 검색하는 기능을 BeanFactory가 제공해주는데, 그러면 둘의 차이가 뭘까?
       - 애플리케이션을 개발할때는 빈은 관리하고 조회하는 기능은 물론이고 수 많은 부가기능이 필요하다.
       - 메세지소스를 통한 국제화기능, 환경변수관리, 애플리케이션 이벤트, 편리한 리소스 조회등.
- 다양한 설정 형식 지원 - 자바코드, xml
- 스프링 빈 설정 메타 정보 - BeanDefinition